### PR TITLE
s/if/it

### DIFF
--- a/src/mdRoutes.js
+++ b/src/mdRoutes.js
@@ -105,7 +105,7 @@ export default [{
       markdown: GeospatialAppInteractions
     },
     {
-      name: '6. Linking if all',
+      name: '6. Linking it all',
       markdown: GeospatialAppLinkingAll
     }, 
     {


### PR DESCRIPTION
Just so happen to browse and notice this typo: `s/if/it`

> https://uber-common.github.io/vis-academy/#/building-a-geospatial-app/6-linking-if-all