### PR TITLE
fix GeospatialAppHasHierarchyInteractive example

### DIFF
--- a/src/demos/building-a-geospatial-app/guidelines/index.js
+++ b/src/demos/building-a-geospatial-app/guidelines/index.js
@@ -200,7 +200,7 @@ export function GeospatialAppHasHierarchy() {
     </div>);
 }
 
-export class HasHierarchyInteractive extends Component {
+export class GeospatialAppHasHierarchyInteractive extends Component {
   constructor() {
     super();
     this.state = {index: null};


### PR DESCRIPTION
Fix geospatial app interactive example.
See http://vis.academy/#/building-a-geospatial-app/visualization-guidelines/do-use-hierarchy
Component is not displayed due to wrong name.