### PR TITLE
remove MAPBOX_STYLE constant

### DIFF
--- a/src/demos/building-a-geospatial-app/starting-code/src/app.js
+++ b/src/demos/building-a-geospatial-app/starting-code/src/app.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 
-const MAPBOX_STYLE = 'mapbox://styles/mapbox/light-v9';
 const MAPBOX_TOKEN = process.env.MapboxAccessToken; // eslint-disable-line
 
 function SetToken() {


### PR DESCRIPTION
the tutorial has this entered directly into state and the constant is not referred to during the tutorial.