### PR TITLE
Missing import causes demo map not to show

### DIFF
--- a/src/docs/building-a-geospatial-app/2-scatterplot-overlay.md
+++ b/src/docs/building-a-geospatial-app/2-scatterplot-overlay.md
@@ -87,6 +87,7 @@ In our example, we are still going to maintain a state to do things like changin
 ```js
 import React, { Component } from 'react';
 import { StaticMap } from 'react-map-gl';
+import DeckGL from 'deck.gl';
 import { MapStylePicker } from './controls';
 
 const INITIAL_VIEW_STATE = {


### PR DESCRIPTION
Missing import statement added to end of section 1 of 2-map-data-overlays-scatterplot doc
import DeckGL from 'deck.gl';

When following the tutorial here: 
http://vis.academy/#/building-a-geospatial-app/2-map-data-overlays-scatterplot

The end of section one code was missing the import statement which causes no map to be shown when run.