### PR TITLE
Define port 3030 in 'starting-code' start script

### DIFF
--- a/src/demos/building-a-geospatial-app/starting-code/package.json
+++ b/src/demos/building-a-geospatial-app/starting-code/package.json
@@ -2,7 +2,7 @@
   "name": "building-a-geospatial-app",
   "version": "0.0.1",
   "scripts": {
-    "start": "webpack-dev-server --config ./webpack.config.js --mode development"
+    "start": "webpack-dev-server --port 3030 --config ./webpack.config.js --mode development"
   },
   "dependencies": {
     "deck.gl": "^6.2.4",


### PR DESCRIPTION
The [documentation](https://vis.academy/#/installing-a-coding-environment/downloading-code-examples) refers to app starting on port `3030` - however, without the port defined the app will start on `8080`. 